### PR TITLE
add support for steps extending Gravity_Flow_Step_Form_Submission

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
+- Added support for steps extending Gravity_Flow_Step_Form_Submission
 - Fixed an issue with the Parent-Child Forms extension where an invalid link message is displayed when the parent entry is on a step that is not a Form Submission step.

--- a/class-form-connector.php
+++ b/class-form-connector.php
@@ -110,7 +110,7 @@ if ( class_exists( 'GFForms' ) ) {
 				return $form;
 			}
 
-			if ( $parent_entry_current_step->get_type() != 'form_submission' ) {
+			if ( ! $parent_entry_current_step instanceof Gravity_Flow_Step_Form_Submission ) {
 				return $form;
 			}
 
@@ -279,7 +279,7 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$current_step = $api->get_current_step( $parent_entry );
 
-			if ( empty( $current_step ) || $current_step->get_type() != 'form_submission' ) {
+			if ( empty( $current_step ) || ! $current_step instanceof Gravity_Flow_Step_Form_Submission ) {
 				return;
 			}
 
@@ -355,7 +355,7 @@ if ( class_exists( 'GFForms' ) ) {
 				return $form_tag;
 			}
 
-			if ( $current_step->get_type() != 'form_submission' ) {
+			if ( ! $current_step instanceof Gravity_Flow_Step_Form_Submission ) {
 				$form_tag .= sprintf( '<div class="validation_error">%s</div>', esc_html__( 'The link to this form is no longer valid.' ) );
 				return $form_tag;
 			}
@@ -518,7 +518,7 @@ if ( class_exists( 'GFForms' ) ) {
 			/* @var Gravity_Flow_Step_Form_Submission $current_step */
 			$current_step = $api->get_current_step( $parent_entry );
 
-			if ( empty( $current_step ) || $current_step->get_type() != 'form_submission' ) {
+			if ( empty( $current_step ) || $current_step instanceof Gravity_Flow_Step_Form_Submission ) {
 				return $value;
 			}
 
@@ -553,7 +553,7 @@ if ( class_exists( 'GFForms' ) ) {
 				return $text;
 			}
 
-			if ( $step->get_type() != 'form_submission' ) {
+			if ( ! $step instanceof Gravity_Flow_Step_Form_Submission ) {
 				return $text;
 			}
 
@@ -593,7 +593,7 @@ if ( class_exists( 'GFForms' ) ) {
 					return;
 				}
 
-				if ( $current_step->get_type() != 'form_submission' ) {
+				if ( ! $current_step instanceof Gravity_Flow_Step_Form_Submission ) {
 					$this->log_debug( __METHOD__ . '() parent entry not on a form submission step. Bailing.' );
 
 					return;


### PR DESCRIPTION
Adds support for steps that extend Gravity_Flow_Step_Form_Submission. [Example](https://github.com/gravityflow/gravityflowlibrary/blob/master/advanced-form-submission-step.php).