### PR TITLE
Add delete entry step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
 - Fixed an issue where a checkbox field (selected) mapped to a text field would return the choice text instead of the choice values.
 - Added the "gravityflowformconnector_{step_type}_use_choice_text" filter allowing the choice text to be returned instead of the choice values.
 - Fixed a PHP deprecation notice on PHP 7.2 with the Form Submission step.
+- Added the Delete Entry step.

--- a/class-form-connector.php
+++ b/class-form-connector.php
@@ -57,6 +57,24 @@ if ( class_exists( 'GFForms' ) ) {
 		private function __clone() {
 		} /* do nothing */
 
+		/**
+		 * Adds the cron job hook.
+		 */
+		public function pre_init() {
+			parent::pre_init();
+			add_action( 'gravityflow_cron', array( $this, 'cron' ), 11 );
+		}
+
+		/**
+		 * Perform tasks when the Gravity Flow cron runs.
+		 */
+		function cron() {
+			$this->log_debug( __METHOD__ . '() Starting cron.' );
+
+			Gravity_Flow_Step_Delete_Entry::cron_delete_local_entries();
+
+			$this->log_debug( __METHOD__ . '() Finished cron.' );
+		}
 
 		public function init() {
 			parent::init();

--- a/class-form-connector.php
+++ b/class-form-connector.php
@@ -59,6 +59,8 @@ if ( class_exists( 'GFForms' ) ) {
 
 		/**
 		 * Adds the cron job hook.
+		 *
+		 * @since 1.3.1-dev
 		 */
 		public function pre_init() {
 			parent::pre_init();
@@ -67,8 +69,10 @@ if ( class_exists( 'GFForms' ) ) {
 
 		/**
 		 * Perform tasks when the Gravity Flow cron runs.
+		 *
+		 * @since 1.3.1-dev
 		 */
-		function cron() {
+		public function cron() {
 			$this->log_debug( __METHOD__ . '() Starting cron.' );
 
 			Gravity_Flow_Step_Delete_Entry::cron_delete_local_entries();

--- a/formconnector.php
+++ b/formconnector.php
@@ -37,10 +37,12 @@ class Gravity_Flow_Form_Connector_Bootstrap {
 		require_once( 'includes/class-step-form-submission.php' );
 		require_once( 'includes/class-step-new-entry.php' );
 		require_once( 'includes/class-step-update-entry.php' );
+		require_once( 'includes/class-step-delete-entry.php' );
 
 		Gravity_Flow_Steps::register( new Gravity_Flow_Step_Form_Submission() );
 		Gravity_Flow_Steps::register( new Gravity_Flow_Step_New_Entry() );
 		Gravity_Flow_Steps::register( new Gravity_Flow_Step_Update_Entry() );
+		Gravity_Flow_Steps::register( new Gravity_Flow_Step_Delete_Entry() );
 
 		require_once( 'class-form-connector.php' );
 

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -28,16 +28,6 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 	 * @return array
 	 */
 	public function get_settings() {
-
-		$forms          = $this->get_forms();
-		$form_choices[] = array(
-			'label' => esc_html__( 'Select a Form', 'gravityflowformconnector' ),
-			'value' => '',
-		);
-		foreach ( $forms as $form ) {
-			$form_choices[] = array( 'label' => $form->title, 'value' => $form->id );
-		}
-
 		$settings = array(
 			'title'  => esc_html__( 'Delete an Entry', 'gravityflow' ),
 			'fields' => array(

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -195,6 +195,11 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 		return $result;
 	}
 
+	/**
+	 * Deletes the local entries when the Gravity Flow cron is processed.
+	 *
+	 * @return void
+	 */
 	public static function cron_delete_local_entries() {
 
 		$form_ids = gravity_flow()->get_workflow_form_ids();

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Gravity Flow Delete Entry Step
+ *
+ *
+ * @package     GravityFlow
+ * @subpackage  Classes/Step
+ * @copyright   Copyright (c) 2015-2018, Steven Henty S.L.
+ * @license     http://opensource.org/licenses/gpl-3.0.php GNU Public License
+ * @since       1.3.1-dev
+ */
+
+if ( class_exists( 'Gravity_Flow_Step' ) ) {
+
+	class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step {
+		public $_step_type = 'delete_entry';
+
+		public function get_label() {
+			return esc_html__( 'Delete an Entry', 'gravityflowformconnector' );
+		}
+
+		/**
+		 * Returns the array of settings for this step.
+		 *
+		 * @return array
+		 */
+		public function get_settings() {
+
+			$forms          = $this->get_forms();
+			$form_choices[] = array(
+				'label' => esc_html__( 'Select a Form', 'gravityflowformconnector' ),
+				'value' => '',
+			);
+			foreach ( $forms as $form ) {
+				$form_choices[] = array( 'label' => $form->title, 'value' => $form->id );
+			}
+
+			$action_choices = $this->action_choices();
+
+			$settings = array(
+				'title'  => esc_html__( 'Update an Entry', 'gravityflow' ),
+				'fields' => array(
+					array(
+						'name'          => 'server_type',
+						'label'         => esc_html__( 'Site', 'gravityflowformconnector' ),
+						'type'          => 'radio',
+						'default_value' => 'local',
+						'horizontal'    => true,
+						'onchange'      => 'jQuery(this).closest("form").submit();',
+						'choices'       => array(
+							array( 'label' => esc_html__( 'This site', 'gravityflowformconnector' ), 'value' => 'local' ),
+							array( 'label' => esc_html__( 'A different site', 'gravityflowformconnector' ), 'value' => 'remote' ),
+						),
+					),
+					array(
+						'name'       => 'remote_site_url',
+						'label'      => esc_html__( 'Site Url', 'gravityflowformconnector' ),
+						'type'       => 'text',
+						'dependency' => array(
+							'field'  => 'server_type',
+							'values' => array( 'remote' ),
+						),
+					),
+					array(
+						'name'       => 'remote_public_key',
+						'label'      => esc_html__( 'Public Key', 'gravityflowformconnector' ),
+						'type'       => 'text',
+						'dependency' => array(
+							'field'  => 'server_type',
+							'values' => array( 'remote' ),
+						),
+					),
+					array(
+						'name'       => 'remote_private_key',
+						'label'      => esc_html__( 'Private Key', 'gravityflowformconnector' ),
+						'type'       => 'text',
+						'dependency' => array(
+							'field'  => 'server_type',
+							'values' => array( 'remote' ),
+						),
+					),
+					array(
+						'name'     => 'target_form_id',
+						'label'    => esc_html__( 'Form', 'gravityflowformconnector' ),
+						'type'     => 'select',
+						'onchange' => "jQuery('#action').val('update');jQuery(this).closest('form').submit();",
+						'choices'  => $form_choices,
+					),
+				),
+			);
+
+			$entry_id_field = array(
+				'name'       => 'update_entry_id',
+				'label'      => esc_html__( 'Entry ID Field', 'gravityflowformconnector' ),
+				'type'       => 'field_select',
+				'tooltip'    => __( 'Select the field which will contain the entry ID of the entry that will be updated. This is used to lookup the entry so it can be updated.', 'gravityflowformconnector' ),
+				'required'   => true,
+				'dependency' => array(
+					'field'  => 'action',
+					'values' => array( 'update', 'approval', 'user_input' ),
+				),
+			);
+
+			if ( function_exists( 'gravity_flow_parent_child' ) ) {
+				$parent_form_choices = array();
+				$entry_meta          = gravity_flow_parent_child()->get_entry_meta( array(), rgget( 'id' ) );
+
+				foreach ( $entry_meta as $meta_key => $meta ) {
+					$parent_form_choices[] = array( 'value' => $meta_key, 'label' => $meta['label'] );
+				}
+
+				if ( ! empty( $parent_form_choices ) ) {
+					$entry_id_field['args']['append_choices'] = $parent_form_choices;
+				}
+			}
+
+			if ( $this->get_setting( 'target_form_id' ) == $this->get_form_id() ) {
+				$self_entry_id_choice = array( array( 'label' => esc_html__( 'Entry ID (Self)', 'gravityflowformconnector' ), 'value' => 'id' ) );
+				if ( ! isset( $entry_id_field['args']['append_choices'] ) ) {
+					$entry_id_field['args']['append_choices'] = array();
+				}
+				$entry_id_field['args']['append_choices'] = array_merge( $entry_id_field['args']['append_choices'], $self_entry_id_choice );
+			}
+
+			$settings['fields'][] = $entry_id_field;
+
+			return $settings;
+		}
+
+		/**
+		 * Deletes a local entry.
+		 *
+		 * @return bool Has the step finished?
+		 */
+		public function process_local_action() {
+			$entry           = $this->get_entry();
+			$target_entry_id = rgar( $entry, $this->update_entry_id );
+
+			if ( empty( $target_entry_id ) ) {
+				return true;
+			}
+
+			$result = GFAPI::delete_entry( $target_entry_id );
+
+			return true;
+		}
+
+		/**
+		 * Updates a remote entry.
+		 *
+		 *
+		 * @return bool Has the step finished?
+		 */
+		public function process_remote_action() {
+			$entry = $this->get_entry();
+
+			$form = $this->get_form();
+
+			$new_entry = $this->do_mapping( $form, $entry );
+
+			$target_form_id = $this->target_form_id;
+
+			$new_entry['form_id'] = $target_form_id;
+
+			$target_entry_id = rgar( $entry, $this->update_entry_id );
+
+			$target_entry_id = apply_filters( 'gravityflowformconnector_update_entry_id', $target_entry_id, $target_form_id, $entry, $form, $this );
+
+			if ( empty( $target_entry_id ) ) {
+				return true;
+			}
+
+			$this->delete_remote_entry( $target_entry_id );
+
+			return true;
+		}
+
+		public function delete_remote_entry( $entry_id ) {
+			$route  = 'entries/' . absint( $entry_id );
+			$method = 'DELETE';
+
+			$result = $this->remote_request( $route, $method );
+
+			return $result;
+		}
+
+	}
+}
+
+
+

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -80,13 +80,6 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 						'values' => array( 'remote' ),
 					),
 				),
-				array(
-					'name'     => 'target_form_id',
-					'label'    => esc_html__( 'Form', 'gravityflowformconnector' ),
-					'type'     => 'select',
-					'onchange' => "jQuery('#action').val('update');jQuery(this).closest('form').submit();",
-					'choices'  => $form_choices,
-				),
 			),
 		);
 
@@ -111,13 +104,16 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 			}
 		}
 
-		if ( $this->get_setting( 'target_form_id' ) == $this->get_form_id() ) {
-			$self_entry_id_choice = array( array( 'label' => esc_html__( 'Entry ID (Self)', 'gravityflowformconnector' ), 'value' => 'id' ) );
-			if ( ! isset( $entry_id_field['args']['append_choices'] ) ) {
-				$entry_id_field['args']['append_choices'] = array();
-			}
-			$entry_id_field['args']['append_choices'] = array_merge( $entry_id_field['args']['append_choices'], $self_entry_id_choice );
+		$self_entry_id_choice = array(
+			array(
+				'label' => esc_html__( 'Entry ID (Self)', 'gravityflowformconnector' ),
+				'value' => 'id'
+			)
+		);
+		if ( ! isset( $entry_id_field['args']['append_choices'] ) ) {
+			$entry_id_field['args']['append_choices'] = array();
 		}
+		$entry_id_field['args']['append_choices'] = array_merge( $entry_id_field['args']['append_choices'], $self_entry_id_choice );
 
 		$settings['fields'][] = $entry_id_field;
 

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -11,182 +11,186 @@
  * @since       1.3.1-dev
  */
 
-if ( class_exists( 'Gravity_Flow_Step' ) ) {
-
-	class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step {
-		public $_step_type = 'delete_entry';
-
-		public function get_label() {
-			return esc_html__( 'Delete an Entry', 'gravityflowformconnector' );
-		}
-
-		/**
-		 * Returns the array of settings for this step.
-		 *
-		 * @return array
-		 */
-		public function get_settings() {
-
-			$forms          = $this->get_forms();
-			$form_choices[] = array(
-				'label' => esc_html__( 'Select a Form', 'gravityflowformconnector' ),
-				'value' => '',
-			);
-			foreach ( $forms as $form ) {
-				$form_choices[] = array( 'label' => $form->title, 'value' => $form->id );
-			}
-
-			$action_choices = $this->action_choices();
-
-			$settings = array(
-				'title'  => esc_html__( 'Update an Entry', 'gravityflow' ),
-				'fields' => array(
-					array(
-						'name'          => 'server_type',
-						'label'         => esc_html__( 'Site', 'gravityflowformconnector' ),
-						'type'          => 'radio',
-						'default_value' => 'local',
-						'horizontal'    => true,
-						'onchange'      => 'jQuery(this).closest("form").submit();',
-						'choices'       => array(
-							array( 'label' => esc_html__( 'This site', 'gravityflowformconnector' ), 'value' => 'local' ),
-							array( 'label' => esc_html__( 'A different site', 'gravityflowformconnector' ), 'value' => 'remote' ),
-						),
-					),
-					array(
-						'name'       => 'remote_site_url',
-						'label'      => esc_html__( 'Site Url', 'gravityflowformconnector' ),
-						'type'       => 'text',
-						'dependency' => array(
-							'field'  => 'server_type',
-							'values' => array( 'remote' ),
-						),
-					),
-					array(
-						'name'       => 'remote_public_key',
-						'label'      => esc_html__( 'Public Key', 'gravityflowformconnector' ),
-						'type'       => 'text',
-						'dependency' => array(
-							'field'  => 'server_type',
-							'values' => array( 'remote' ),
-						),
-					),
-					array(
-						'name'       => 'remote_private_key',
-						'label'      => esc_html__( 'Private Key', 'gravityflowformconnector' ),
-						'type'       => 'text',
-						'dependency' => array(
-							'field'  => 'server_type',
-							'values' => array( 'remote' ),
-						),
-					),
-					array(
-						'name'     => 'target_form_id',
-						'label'    => esc_html__( 'Form', 'gravityflowformconnector' ),
-						'type'     => 'select',
-						'onchange' => "jQuery('#action').val('update');jQuery(this).closest('form').submit();",
-						'choices'  => $form_choices,
-					),
-				),
-			);
-
-			$entry_id_field = array(
-				'name'       => 'update_entry_id',
-				'label'      => esc_html__( 'Entry ID Field', 'gravityflowformconnector' ),
-				'type'       => 'field_select',
-				'tooltip'    => __( 'Select the field which will contain the entry ID of the entry that will be updated. This is used to lookup the entry so it can be updated.', 'gravityflowformconnector' ),
-				'required'   => true,
-				'dependency' => array(
-					'field'  => 'action',
-					'values' => array( 'update', 'approval', 'user_input' ),
-				),
-			);
-
-			if ( function_exists( 'gravity_flow_parent_child' ) ) {
-				$parent_form_choices = array();
-				$entry_meta          = gravity_flow_parent_child()->get_entry_meta( array(), rgget( 'id' ) );
-
-				foreach ( $entry_meta as $meta_key => $meta ) {
-					$parent_form_choices[] = array( 'value' => $meta_key, 'label' => $meta['label'] );
-				}
-
-				if ( ! empty( $parent_form_choices ) ) {
-					$entry_id_field['args']['append_choices'] = $parent_form_choices;
-				}
-			}
-
-			if ( $this->get_setting( 'target_form_id' ) == $this->get_form_id() ) {
-				$self_entry_id_choice = array( array( 'label' => esc_html__( 'Entry ID (Self)', 'gravityflowformconnector' ), 'value' => 'id' ) );
-				if ( ! isset( $entry_id_field['args']['append_choices'] ) ) {
-					$entry_id_field['args']['append_choices'] = array();
-				}
-				$entry_id_field['args']['append_choices'] = array_merge( $entry_id_field['args']['append_choices'], $self_entry_id_choice );
-			}
-
-			$settings['fields'][] = $entry_id_field;
-
-			return $settings;
-		}
-
-		/**
-		 * Deletes a local entry.
-		 *
-		 * @return bool Has the step finished?
-		 */
-		public function process_local_action() {
-			$entry           = $this->get_entry();
-			$target_entry_id = rgar( $entry, $this->update_entry_id );
-
-			if ( empty( $target_entry_id ) ) {
-				return true;
-			}
-
-			$result = GFAPI::delete_entry( $target_entry_id );
-
-			return true;
-		}
-
-		/**
-		 * Updates a remote entry.
-		 *
-		 *
-		 * @return bool Has the step finished?
-		 */
-		public function process_remote_action() {
-			$entry = $this->get_entry();
-
-			$form = $this->get_form();
-
-			$new_entry = $this->do_mapping( $form, $entry );
-
-			$target_form_id = $this->target_form_id;
-
-			$new_entry['form_id'] = $target_form_id;
-
-			$target_entry_id = rgar( $entry, $this->update_entry_id );
-
-			$target_entry_id = apply_filters( 'gravityflowformconnector_update_entry_id', $target_entry_id, $target_form_id, $entry, $form, $this );
-
-			if ( empty( $target_entry_id ) ) {
-				return true;
-			}
-
-			$this->delete_remote_entry( $target_entry_id );
-
-			return true;
-		}
-
-		public function delete_remote_entry( $entry_id ) {
-			$route  = 'entries/' . absint( $entry_id );
-			$method = 'DELETE';
-
-			$result = $this->remote_request( $route, $method );
-
-			return $result;
-		}
-
-	}
+if ( ! class_exists( 'Gravity_Flow_Step_New_Entry' ) ) {
+	require_once( 'class-step-new-entry.php' );
 }
 
+class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
+	public $_step_type = 'delete_entry';
 
+	public function get_label() {
+		return esc_html__( 'Delete an Entry', 'gravityflowformconnector' );
+	}
 
+	/**
+	 * Returns the array of settings for this step.
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+
+		$forms          = $this->get_forms();
+		$form_choices[] = array(
+			'label' => esc_html__( 'Select a Form', 'gravityflowformconnector' ),
+			'value' => '',
+		);
+		foreach ( $forms as $form ) {
+			$form_choices[] = array( 'label' => $form->title, 'value' => $form->id );
+		}
+
+		$settings = array(
+			'title'  => esc_html__( 'Delete an Entry', 'gravityflow' ),
+			'fields' => array(
+				array(
+					'name'          => 'server_type',
+					'label'         => esc_html__( 'Site', 'gravityflowformconnector' ),
+					'type'          => 'radio',
+					'default_value' => 'local',
+					'horizontal'    => true,
+					'onchange'      => 'jQuery(this).closest("form").submit();',
+					'choices'       => array(
+						array( 'label' => esc_html__( 'This site', 'gravityflowformconnector' ), 'value' => 'local' ),
+						array( 'label' => esc_html__( 'A different site', 'gravityflowformconnector' ), 'value' => 'remote' ),
+					),
+				),
+				array(
+					'name'       => 'remote_site_url',
+					'label'      => esc_html__( 'Site Url', 'gravityflowformconnector' ),
+					'type'       => 'text',
+					'dependency' => array(
+						'field'  => 'server_type',
+						'values' => array( 'remote' ),
+					),
+				),
+				array(
+					'name'       => 'remote_public_key',
+					'label'      => esc_html__( 'Public Key', 'gravityflowformconnector' ),
+					'type'       => 'text',
+					'dependency' => array(
+						'field'  => 'server_type',
+						'values' => array( 'remote' ),
+					),
+				),
+				array(
+					'name'       => 'remote_private_key',
+					'label'      => esc_html__( 'Private Key', 'gravityflowformconnector' ),
+					'type'       => 'text',
+					'dependency' => array(
+						'field'  => 'server_type',
+						'values' => array( 'remote' ),
+					),
+				),
+				array(
+					'name'     => 'target_form_id',
+					'label'    => esc_html__( 'Form', 'gravityflowformconnector' ),
+					'type'     => 'select',
+					'onchange' => "jQuery('#action').val('update');jQuery(this).closest('form').submit();",
+					'choices'  => $form_choices,
+				),
+			),
+		);
+
+		$entry_id_field = array(
+			'name'       => 'delete_entry_id',
+			'label'      => esc_html__( 'Entry ID Field', 'gravityflowformconnector' ),
+			'type'       => 'field_select',
+			'tooltip'    => __( 'Select the field which will contain the entry ID of the entry that will be deleted. This is used to lookup the entry so it can be deleted.', 'gravityflowformconnector' ),
+			'required'   => true,
+		);
+
+		if ( function_exists( 'gravity_flow_parent_child' ) ) {
+			$parent_form_choices = array();
+			$entry_meta          = gravity_flow_parent_child()->get_entry_meta( array(), rgget( 'id' ) );
+
+			foreach ( $entry_meta as $meta_key => $meta ) {
+				$parent_form_choices[] = array( 'value' => $meta_key, 'label' => $meta['label'] );
+			}
+
+			if ( ! empty( $parent_form_choices ) ) {
+				$entry_id_field['args']['append_choices'] = $parent_form_choices;
+			}
+		}
+
+		if ( $this->get_setting( 'target_form_id' ) == $this->get_form_id() ) {
+			$self_entry_id_choice = array( array( 'label' => esc_html__( 'Entry ID (Self)', 'gravityflowformconnector' ), 'value' => 'id' ) );
+			if ( ! isset( $entry_id_field['args']['append_choices'] ) ) {
+				$entry_id_field['args']['append_choices'] = array();
+			}
+			$entry_id_field['args']['append_choices'] = array_merge( $entry_id_field['args']['append_choices'], $self_entry_id_choice );
+		}
+
+		$settings['fields'][] = $entry_id_field;
+
+		return $settings;
+	}
+
+	/**
+	 * Deletes a local entry.
+	 *
+	 * @return bool Has the step finished?
+	 */
+	public function process_local_action() {
+		$entry           = $this->get_entry();
+		$target_entry_id = rgar( $entry, $this->delete_entry_id );
+
+		if ( empty( $target_entry_id ) ) {
+			return true;
+		}
+
+		if ( $target_entry_id == $entry['id'] ) {
+			add_action( 'gravityflow_post_process_workflow', array( $this, 'delete_local_entry_post_process_workflow' ), 10, 3 );
+		} else {
+			$this->delete_local_entry( $target_entry_id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deletes a remote entry.
+	 *
+	 * @return bool Has the step finished?
+	 */
+	public function process_remote_action() {
+		$entry = $this->get_entry();
+
+		$form = $this->get_form();
+
+		$target_form_id = $this->target_form_id;
+
+		$target_entry_id = rgar( $entry, $this->delete_entry_id );
+
+		$target_entry_id = apply_filters( 'gravityflowformconnector_delete_entry_id', $target_entry_id, $target_form_id, $entry, $form, $this );
+
+		if ( empty( $target_entry_id ) ) {
+			return true;
+		}
+
+		$this->delete_remote_entry( $target_entry_id );
+
+		return true;
+	}
+
+	public function delete_remote_entry( $entry_id ) {
+		$route  = 'entries/' . absint( $entry_id );
+		$method = 'DELETE';
+
+		$result = $this->remote_request( $route, $method );
+
+		return $result;
+	}
+
+	public function delete_local_entry( $entry_id ) {
+		return GFAPI::delete_entry( $entry_id );
+	}
+
+	public function delete_local_entry_post_process_workflow( $form, $entry_id, $step_id ) {
+		if ( $step_id !== $this->get_id() || $entry_id !== $this->get_entry_id() ) {
+			return;
+		}
+
+		$this->log_debug( __METHOD__ . '(): running for entry #' . $entry_id );
+		$this->delete_local_entry( $entry_id );
+	}
+
+}

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -167,6 +167,13 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 		return true;
 	}
 
+	/**
+	 * Sends a request to delete a remote entry.
+	 *
+	 * @param int $entry_id The ID of the entry to be deleted.
+	 *
+	 * @return bool
+	 */
 	public function delete_remote_entry( $entry_id ) {
 		$route  = 'entries/' . absint( $entry_id );
 		$method = 'DELETE';
@@ -178,6 +185,13 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 		return $result;
 	}
 
+	/**
+	 * Deletes the current entry.
+	 *
+	 * @param array $form     The current form.
+	 * @param int   $entry_id The ID of the current entry.
+	 * @param int   $step_id  The ID of the last step which was processed.
+	 */
 	public function delete_local_entry_post_process_workflow( $form, $entry_id, $step_id ) {
 		if ( $step_id !== $this->get_id() || $entry_id !== $this->get_entry_id() ) {
 			return;

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -40,7 +40,10 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 					'onchange'      => 'jQuery(this).closest("form").submit();',
 					'choices'       => array(
 						array( 'label' => esc_html__( 'This site', 'gravityflowformconnector' ), 'value' => 'local' ),
-						array( 'label' => esc_html__( 'A different site', 'gravityflowformconnector' ), 'value' => 'remote' ),
+						array(
+							'label' => esc_html__( 'A different site', 'gravityflowformconnector' ),
+							'value' => 'remote'
+						),
 					),
 				),
 				array(
@@ -68,6 +71,27 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 					'dependency' => array(
 						'field'  => 'server_type',
 						'values' => array( 'remote' ),
+					),
+				),
+				array(
+					'name'          => 'delete_action',
+					'label'         => esc_html__( 'Delete Action', 'gravityflowformconnector' ),
+					'type'          => 'radio',
+					'default_value' => 'permanently',
+					'horizontal'    => true,
+					'choices'       => array(
+						array(
+							'label' => esc_html__( 'Permanently delete the entry', 'gravityflowformconnector' ),
+							'value' => 'permanently',
+						),
+						array(
+							'label' => esc_html__( 'Move the entry to the trash', 'gravityflowformconnector' ),
+							'value' => 'trash',
+						),
+					),
+					'dependency'    => array(
+						'field'  => 'server_type',
+						'values' => array( 'local' ),
 					),
 				),
 			),
@@ -146,10 +170,10 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 
 		$this->log_debug( __METHOD__ . '(): running for entry #' . $target_entry_id );
 
-		if ( $this->trash_entry ) {
+		if ( $this->delete_action === 'trash' ) {
 			$result = GFAPI::update_entry_property( $target_entry_id, 'status', 'trash' );
 			$this->log_debug( __METHOD__ . '() trashed entry: ' . var_export( $result, 1 ) );
-		} elseif ( $target_entry_id === $entry['id'] ) {
+		} elseif ( $target_entry_id == $this->get_entry_id() ) {
 			gform_add_meta( $target_entry_id, 'workflow_delete_entry', 1 );
 			$this->log_debug( __METHOD__ . '(): scheduled for deletion.' );
 		} else {

--- a/includes/class-step-delete-entry.php
+++ b/includes/class-step-delete-entry.php
@@ -126,17 +126,21 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 	 * @return bool Has the step finished?
 	 */
 	public function process_local_action() {
-		$entry           = $this->get_entry();
+		$entry = $this->get_entry();
 		$target_entry_id = rgar( $entry, $this->delete_entry_id );
 
 		if ( empty( $target_entry_id ) ) {
 			return true;
 		}
 
+		$this->log_debug( __METHOD__ . '(): running for entry #' . $target_entry_id );
+
 		if ( $target_entry_id == $entry['id'] ) {
+			$this->log_debug( __METHOD__ . '(): entry to be deleted is the current entry; deletion will occur post processing' );
 			add_action( 'gravityflow_post_process_workflow', array( $this, 'delete_local_entry_post_process_workflow' ), 10, 3 );
 		} else {
-			$this->delete_local_entry( $target_entry_id );
+			$result = GFAPI::delete_entry( $target_entry_id );
+			$this->log_debug( __METHOD__ . '(): result => ' . print_r( $result, 1 ) );
 		}
 
 		return true;
@@ -149,14 +153,10 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 	 */
 	public function process_remote_action() {
 		$entry = $this->get_entry();
-
-		$form = $this->get_form();
-
-		$target_form_id = $this->target_form_id;
+		$form  = $this->get_form();
 
 		$target_entry_id = rgar( $entry, $this->delete_entry_id );
-
-		$target_entry_id = apply_filters( 'gravityflowformconnector_delete_entry_id', $target_entry_id, $target_form_id, $entry, $form, $this );
+		$target_entry_id = apply_filters( 'gravityflowformconnector_delete_entry_id', $target_entry_id, $entry, $form, $this );
 
 		if ( empty( $target_entry_id ) ) {
 			return true;
@@ -171,13 +171,11 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 		$route  = 'entries/' . absint( $entry_id );
 		$method = 'DELETE';
 
+		$this->log_debug( __METHOD__ . '(): running for entry #' . $entry_id );
 		$result = $this->remote_request( $route, $method );
+		$this->log_debug( __METHOD__ . '(): result => ' . print_r( $result, 1 ) );
 
 		return $result;
-	}
-
-	public function delete_local_entry( $entry_id ) {
-		return GFAPI::delete_entry( $entry_id );
 	}
 
 	public function delete_local_entry_post_process_workflow( $form, $entry_id, $step_id ) {
@@ -186,7 +184,8 @@ class Gravity_Flow_Step_Delete_Entry extends Gravity_Flow_Step_New_Entry {
 		}
 
 		$this->log_debug( __METHOD__ . '(): running for entry #' . $entry_id );
-		$this->delete_local_entry( $entry_id );
+		$result = GFAPI::delete_entry( $entry_id );
+		$this->log_debug( __METHOD__ . '(): result => ' . print_r( $result, 1 ) );
 	}
 
 }


### PR DESCRIPTION
Adds a new step type which will delete the specified entry when run.

If the entry to be deleted is the current entry, deletion will be delayed until the `gravityflow_post_process_workflow` hook runs, preventing a fatal error occuring when `Gravity_Flow::process_workflow()` refreshes the entry before attempting to get the next step.