### PR TITLE
Restore list field mapping functionality

### DIFF
--- a/includes/class-step-new-entry.php
+++ b/includes/class-step-new-entry.php
@@ -199,6 +199,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 
 			$new_entry = $this->do_mapping( $form, $entry );
 
+			gravity_flow()->log_debug( __METHOD__ . '(): JO: ' . print_r( $new_entry, true ) );
 			if ( ! empty( $new_entry ) ) {
 				$new_entry['form_id'] = $this->target_form_id;
 				$entry_id = GFAPI::add_entry( $new_entry );
@@ -457,7 +458,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 						foreach ( $inputs as $input ) {
 							$fields[] = array(
 								'value' => $input['id'],
-								'label' => GFCommon::get_label( $field, $input['id'] )
+								'label' => GFCommon::get_label( $field, $input['id'] ),
 							);
 						}
 					} elseif ( $input_type == 'list' && $field->enableColumns && $field_is_valid_type && ! $exclude_field ) {
@@ -606,7 +607,11 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 				 * @param Gravity_Flow_Step $this            The current step.
 				 */
 				$use_choice_text = apply_filters( 'gravityflowformconnector_' . $this->get_type() . '_use_choice_text', false, $source_field, $entry, $this );
-				$field_value     = $source_field->get_value_export( $entry, $source_field_id, $use_choice_text );
+				if ( $source_field->type == 'list' && isset( $entry[ $source_field_id ] ) ) {
+					$field_value = $entry[ $source_field_id ];
+				} else {
+					$field_value = $source_field->get_value_export( $entry, $source_field_id, $use_choice_text );
+				}
 			}
 
 			return $field_value;


### PR DESCRIPTION
Between v1.3 and v1.4 a bug was introduced that changed the get_source_field_value result (for a list) to pass a JSON set versus serialized which the GFAPI expects for new/updates. Resolves HS#6477.

**To Test**
Consider using [gravityforms-export-2018-08-05.json.zip](https://github.com/gravityflow/gravityflowformconnector/files/2259922/gravityforms-export-2018-08-05.json.zip) which contains the following:

1. Use gravityflowformconnector master branch.
1. Create two forms that both have a list field in them with same number of columns and a field to capture entry ID from cross-connection.
1. Source form workflow:
- Create New Entry step mapping the list fields together.
- User Input step to modify the list
- Update Entry step mapping the list fields together.
1. Note that between each step the destination form does not have list value created/updated with entry.
1. Switch to 6477-list-field branch and repeat steps above. Note that list value is create/updated.

