### PR TITLE
Add "gravityflowformconnector_source_form" to allow filtering the for…

### DIFF
--- a/includes/class-step-update-entry.php
+++ b/includes/class-step-update-entry.php
@@ -263,8 +263,18 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			$api = new Gravity_Flow_API( $target_form_id );
 
 			$steps = $api->get_steps();
-			
-			$form = apply_filters( 'gravityflowformconnector_source_form', $this->get_form(), $entry );
+
+			/**
+			 * Allows the form of entry for update to be customized/hydrated.
+			 *
+			 * @since 1.7.4
+			 *
+			 * @param array|null $form
+			 * @param array|null $entry
+			 *
+			 * @return array
+			 */
+			$form = apply_filters( 'gravityflowformconnector_update_entry_form', $this->get_form(), $entry );
 
 			$target_entry_id = rgar( $entry, $this->update_entry_id );
 

--- a/includes/class-step-update-entry.php
+++ b/includes/class-step-update-entry.php
@@ -263,8 +263,8 @@ if ( class_exists( 'Gravity_Flow_Step' ) ) {
 			$api = new Gravity_Flow_API( $target_form_id );
 
 			$steps = $api->get_steps();
-
-			$form = $this->get_form();
+			
+			$form = apply_filters( 'gravityflowformconnector_source_form', $this->get_form(), $entry );
 
 			$target_entry_id = rgar( $entry, $this->update_entry_id );
 


### PR DESCRIPTION
…m object that will be used to handle the source mapping when updating an entry.

This allows Populate Anything to properly hydrate the source form before the mapping occurs.
We can do the same for the target form via the GF core filter `gform_form_pre_update_entry`. 

Happy to add inline documentation for this filter once I have confirmation that the hook will be accepted.