### PR TITLE
Fix entries released from the Form Submission step before the payment completed with Stripe Checkout

### DIFF
--- a/class-form-connector.php
+++ b/class-form-connector.php
@@ -387,6 +387,13 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$payment_status = strtolower( rgar( $entry, 'payment_status' ) );
 
+			// Check if there's a Stripe Checkout feed.
+			if ( function_exists( 'gf_stripe' ) ) {
+				if ( gf_stripe()->has_feed( $form_id, true ) && gf_stripe()->is_stripe_checkout_enabled() ) {
+					$payment_status = $entry['payment_status'] = 'processing';
+				}
+			}
+
 			if ( empty( $payment_status ) || $payment_status == 'paid' ) {
 				$assignee_status = 'complete';
 				$current_step->process_assignee_status( $assignee, $assignee_status, $form );


### PR DESCRIPTION
re:[HS#12170](https://secure.helpscout.net/conversation/1038976248/12170?folderId=2308452)

This PR fixes an issue where entries released from the Form Submission step before the payment completed with Stripe Checkout.

## Testing instructions
1. Use these forms for testing: 
[gravityforms-export-2020-01-12.json.zip](https://github.com/gravityflow/gravityflowformconnector/files/4050693/gravityforms-export-2020-01-12.json.zip)
2. Set your Stripe payment collection method to "Stripe Checkout".
3. In the master branch, entries will be released from the form submission step before the payment completed; with this PR, that should be fixed.

### Note: the tests are currently failed and will be fix with another PR #30 .
