### PR TITLE
Fix a fatal error during merge tag replacement with Gravity Flow 2.5.10

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Added the gravityflowformconnector_new_entry_form and gravityflowformconnector_update_field_values_form filters.
+- Fixed issue with merge tag evaluation that caused a fatal error involving certain conditional logic setup.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,2 @@
 - Added the gravityflowformconnector_new_entry_form and gravityflowformconnector_update_field_values_form filters.
-- Fixed issue with merge tag evaluation that caused a fatal error involving certain conditional logic setup.
+- Fixed issue with merge tag evaluation that caused a fatal error involving certain conditional logic setup. Update to Gravity Flow 2.5.11 will also be required.

--- a/class-form-connector.php
+++ b/class-form-connector.php
@@ -657,6 +657,10 @@ if ( class_exists( 'GFForms' ) ) {
 		 */
 		public function filter_gform_pre_replace_merge_tags( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format ) {
 
+			if ( strpos( $text, '{' ) === false || empty( $entry ) ) {
+				return $text;
+			}
+
 			$step = gravity_flow()->get_current_step( $form, $entry );
 
 			if ( empty( $step ) ) {

--- a/class-form-connector.php
+++ b/class-form-connector.php
@@ -661,7 +661,9 @@ if ( class_exists( 'GFForms' ) ) {
 				return $text;
 			}
 
+			remove_filter( 'gform_pre_replace_merge_tags', array( $this, 'filter_gform_pre_replace_merge_tags' ) );
 			$step = gravity_flow()->get_current_step( $form, $entry );
+			add_filter( 'gform_pre_replace_merge_tags', array( $this, 'filter_gform_pre_replace_merge_tags' ), 10, 7 );
 
 			if ( empty( $step ) ) {
 				return $text;


### PR DESCRIPTION
re: [HS#13809](https://secure.helpscout.net/conversation/1188384647/13809?folderId=1113492)

This updates `Gravity_Flow_Form_Connector::filter_gform_pre_replace_merge_tags()` to return early when the text being processed doesn't contain a merge tag or when the entry is empty.

This fixes a fatal error which occurs when merge tag processing runs during evaulation of conditional logic for the first step.

## Testing Instructions
- Submit test form from the slack thread about this issue
- Find fatal error occurs
- Switch to this branch
- Submit form again
- Find the fatal error does not occur